### PR TITLE
Parameter to adjust acknowledge wait time

### DIFF
--- a/src/Joystick_ESP32S2.cpp
+++ b/src/Joystick_ESP32S2.cpp
@@ -486,12 +486,13 @@ Joystick_::Joystick_(
   }
 
 
-void Joystick_::begin(bool initAutoSendState, uint8_t intervalMs)
+void Joystick_::begin(bool initAutoSendState, uint32_t intervalMs_u32)
 {
 	HID.begin();
 	_autoSendState = initAutoSendState;
 	sendState();
 	_usbDeviceStatus=true;
+	_intervalMs_u32 = intervalMs_u32;
 }
 
 void Joystick_::end()
@@ -700,7 +701,7 @@ void Joystick_::sendState()
 
 
 	if (HID.ready()) {
-		bool success=HID.SendReport(_hidReportId, data, sizeof(data),2);
+		bool success=HID.SendReport(_hidReportId, data, sizeof(data), _intervalMs_u32);
 		if (!success) 
 		{
 			_reportFailCount++;

--- a/src/Joystick_ESP32S2.h
+++ b/src/Joystick_ESP32S2.h
@@ -111,6 +111,7 @@ public:
 	uint8_t *customHidReportDescriptor;
     bool      _usbDeviceStatus = false;
 	int hidReportDescriptorSize;
+    uint32_t _intervalMs_u32 = 10;
 
     Joystick_(
         uint8_t hidReportId = JOYSTICK_DEFAULT_REPORT_ID,
@@ -129,7 +130,7 @@ public:
         bool includeBrake = true,
         bool includeSteering = true);
 
-    void begin(bool initAutoSendState = true, uint8_t interval_ms = 2);
+    void begin(bool initAutoSendState = true, uint32_t intervalMs_u32 = 10);
 	
 	void end();
     


### PR DESCRIPTION
HID reports are acknowledged by the host PC. If send intervall is to frequent, the host might mute the device. Therefore, a parameter was added to adjust the wait response time.